### PR TITLE
Add visit counter and countdown 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -74,5 +74,7 @@
       redirect();
     </script>
   </head>
-  <body></body>
+  <body>
+    <img src="https://count.getloli.com/get/@:rinmescount" alt=":rinmescount" />
+  </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ And on GitHub trending!
 1. There is no need for the pound symbol - short URLs look clean like this:
    `ccb.wtf/1` instead of looking like this: `ccb.wtf/#1`.
 
+1. Tracks visit counts using [count.getloli.com](https://count.getloli.com).
+   Display the counter with
+   `<img src="https://count.getloli.com/get/@:rinmescount" alt=":rinmescount" />`.
+
 ## 💡 How does this work?
 
 _Thanks to @kidGodzilla for the pretty neat explanation

--- a/index.html
+++ b/index.html
@@ -2,14 +2,35 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="minimum-scale=1, initial-scale=1, width=device-width"
-    />
-    <title>Invalid URL!</title>
+    <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+    <title>404 - Page Not Found</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        text-align: center;
+        margin-top: 20vh;
+      }
+      #counter {
+        font-weight: bold;
+      }
+    </style>
+    <script>
+      var seconds = 5;
+      function updateCounter() {
+        if (seconds <= 0) {
+          window.location.href = "https://youtu.be/dQw4w9WgXcQ?si=a3bIQRqx2DqLgUDW";
+          return;
+        }
+        document.getElementById("counter").textContent = seconds;
+        seconds--;
+        setTimeout(updateCounter, 1000);
+      }
+      window.addEventListener("load", updateCounter);
+    </script>
   </head>
   <body>
-    <p>Short URL is invalid! (Or you have been spamming the site too much)</p>
+    <h1>404 - Page Not Found</h1>
+    <p>Redirecting in <span id="counter">5</span> seconds...</p>
     <p>
       <a href="https://github.com/nelsontky/gh-pages-url-shortener">
         Learn more about this URL shortener


### PR DESCRIPTION
## Summary
- log link visits through getloli counter before redirecting
- add friendly 404 page with 5 second countdown to a Rickroll
- document how to embed the new hit counter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a224e0f0308326a2f3a4685f8b2afa